### PR TITLE
Erstatter jCenter med Maven Central. Bumper versjoner.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.gradle
+.idea
+/out
+build
+buildSrc/out
+*.iml
+*.ipr
+*.iws
+.DS_Store

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,16 +1,15 @@
-val ktorVersion = "1.4.1"
+val ktorVersion = "1.6.7"
 val jupiterVersion = "5.4.1"
-val kluentVersion = "1.61"
+val kluentVersion = "1.68"
 
 plugins {
     `maven-publish`
 
-    kotlin("jvm") version "1.4.10"
+    kotlin("jvm") version "1.6.10"
 }
 
 
 dependencies {
-    api(kotlin("stdlib-jdk8"))
     implementation("io.ktor:ktor-server-netty:$ktorVersion")
     testImplementation(kotlin("test-junit5"))
     testImplementation("org.junit.jupiter:junit-jupiter-engine:$jupiterVersion")
@@ -19,7 +18,6 @@ dependencies {
 }
 
 repositories {
-    jcenter()
     mavenCentral()
 }
 
@@ -37,10 +35,10 @@ publishing {
 
 tasks {
     compileKotlin {
-        kotlinOptions.jvmTarget = "1.8"
+        kotlinOptions.jvmTarget = "13"
     }
     compileTestKotlin {
-        kotlinOptions.jvmTarget = "1.8"
+        kotlinOptions.jvmTarget = "13"
     }
 
     withType<Test> {

--- a/src/main/kotlin/no/nav/personbruker/ktor/features/CaseInsensitiveStringSet.kt
+++ b/src/main/kotlin/no/nav/personbruker/ktor/features/CaseInsensitiveStringSet.kt
@@ -41,7 +41,7 @@ internal class CaseInsensitiveStringSet: MutableSet<String> {
 }
 
 private class CaseInsensitiveString(val value: String) {
-    val cachedHash = value.toLowerCase().hashCode()
+    val cachedHash = value.lowercase().hashCode()
 
     override fun equals(other: Any?): Boolean {
         return other is CaseInsensitiveString

--- a/src/main/kotlin/no/nav/personbruker/ktor/features/NonStandardCORS.kt
+++ b/src/main/kotlin/no/nav/personbruker/ktor/features/NonStandardCORS.kt
@@ -35,7 +35,7 @@ class NonStandardCORS(configuration: Configuration) {
 
     val methods: Set<HttpMethod> = HashSet<HttpMethod>(configuration.methods + Configuration.CorsDefaultMethods)
 
-    val allHeadersSet: Set<String> = allHeaders.map { it.toLowerCase() }.toSet()
+    val allHeadersSet: Set<String> = allHeaders.map { it.lowercase() }.toSet()
 
     private val allowNonSimpleContentTypes: Boolean = configuration.allowNonSimpleContentTypes
 
@@ -179,7 +179,7 @@ class NonStandardCORS(configuration: Configuration) {
     private fun ApplicationCall.corsCheckRequestHeaders(): Boolean {
         val requestHeaders =
             request.headers.getAll(HttpHeaders.AccessControlRequestHeaders)?.flatMap { it.split(",") }?.map {
-                it.trim().toLowerCase()
+                it.trim().lowercase()
             } ?: emptyList()
 
         return requestHeaders.none { it !in allHeadersSet }


### PR DESCRIPTION
 Behovet for denne featuren er snart borte, men den er fortsatt i bruk i innloggingsstatus. Venter med å arkivere til innloggingsstatus ikke bruker den lengre.